### PR TITLE
Initial working version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM quay.io/aptible/debian
+
+# Install general dependencies (git, build-essential)
+RUN apt-install build-essential git
+
+# Install Ruby and Bundler
+RUN apt-install zlib1g-dev libssl-dev libreadline6-dev libyaml-dev
+RUN cd /tmp && \
+    wget -q http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.gz && \
+    tar xzf ruby-2.1.5.tar.gz && \
+    cd ruby-2.1.5 && ./configure --enable-shared --prefix=/usr && \
+    make && make install && cd .. && rm -rf ruby-2.1.5*
+RUN gem install -N bundler
+
+# Install NPM and Node.js
+RUN cd /usr && \
+    wget http://nodejs.org/dist/v0.10.33/node-v0.10.33-linux-x64.tar.gz && \
+    tar --strip-components 1 -xzf node-v0.10.33-linux-x64.tar.gz && \
+    rm -f node-v0.10.33*
+
+# Install Python
+RUN apt-install python3-minimal
+RUN ln -s python3 /usr/bin/python
+
+ADD test /tmp/test
+RUN bats /tmp/test

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,22 @@
+Copyright (c) 2013 Aptible, Inc.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+DOCKER = docker
+ENV = $(shell cat .dockeropts)
+REPO = quay.io/aptible/webapp-essential
+
+TAG = $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
+ifeq ($(TAG), master)
+	TAG = latest
+else ifeq ($(TAG), HEAD)
+	TAG = latest
+endif
+
+all: release
+
+run: build
+	$(DOCKER) run $(ENV) $(REPO)
+
+release: build
+	$(DOCKER) push $(REPO)
+
+build:
+	$(DOCKER) build -t $(REPO):$(TAG) .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,34 @@
 # ![](https://gravatar.com/avatar/11d3bc4c3163e3d238d558d5c9d98efe?s=64) aptible/webapp-essential
 
+[![Docker Repository on Quay.io](https://quay.io/repository/aptible/webapp-essential/status)](https://quay.io/repository/aptible/webapp-essential)
+
+A Docker image supporting many common webapp frameworks. Currently, the latest versions of Ruby, Node.js and Python are included.
+
+## Installation and Usage
+
+    docker pull quay.io/aptible/webapp-essential
+    docker run quay.io/aptible/webapp-essential
+
+## Included languages/tools
+
+* Ruby 2.1.5 (including Bundler)
+* Node.js v0.10.33 (including NPM)
+* Python 3.2.3
+* Git
+* Debian build-essential (includes gcc, g++)
+
+## Tests
+
+Tests are run as part of the `Dockerfile` build. To execute them separately within a container, run:
+
+    bats test
+
+## Deployment
+
+To push the Docker image to Quay, run the following command:
+
+    make release
+
 ## Copyright and License
 
 MIT License, see [LICENSE](LICENSE.md) for details.

--- a/test/web-essential.bats
+++ b/test/web-essential.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+@test "It should install Node v0.10.33" {
+  node -v | grep v0.10.33
+}
+
+@test "It should install NPM" {
+  which npm
+}
+
+@test "It should install Ruby 2.1.5" {
+  ruby -v | grep 2.1.5
+}
+
+@test "It should install Bundler" {
+  which bundler
+}
+
+@test "It should install Python 3.2.3" {
+  run python --version
+  [[ $output =~ "3.2.3" ]]
+}


### PR DESCRIPTION
- Ruby 2.1.5
- Node.js v0.10.33
- Python 3.2.3

It's a big image :disappointed: at 430.6 MB, but still smaller than the Ubuntu-based quay.io.aptible/ruby image (473 MB). Here's the relevant part of the image history; @aaw, thoughts on compressing it further? I could maybe install build-essential as part of the Ruby install and then remove it (and all its dependent packages as part of the same `RUN` instruction as installing Ruby)? Perhaps we could have two tags/branches: one for build-essential, one without?

```
$ docker history quay.io/aptible/webapp-essential
IMAGE               CREATED             CREATED BY                                      SIZE
6768b93f2d23        17 minutes ago      /bin/sh -c bats /tmp/test                       0 B
ba1538e3ee1a        17 minutes ago      /bin/sh -c #(nop) ADD dir:2e1d54bf59c08460261   352 B
50066358fba2        19 minutes ago      /bin/sh -c ln -s python3 /usr/bin/python        7 B
7281ed681734        19 minutes ago      /bin/sh -c apt-install python3-minimal          27.62 MB
03d5e3cea7f7        19 minutes ago      /bin/sh -c cd /usr &&     wget http://nodejs.   17.44 MB
db44c1f5abe2        19 minutes ago      /bin/sh -c gem install -N bundler               4.033 MB
98c9f7ab87a5        19 minutes ago      /bin/sh -c cd /tmp &&     wget -q http://cach   109.8 MB
ea8d1bc7134b        23 minutes ago      /bin/sh -c apt-install zlib1g-dev libssl-dev    10.6 MB
de3bf6ea9d67        24 minutes ago      /bin/sh -c apt-install build-essential git      165.2 MB
```
